### PR TITLE
Avoid spread to support node 4

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -1,6 +1,8 @@
 'use strict';
 
-module.exports = function(Parent, ...mixins) {
+module.exports = function(Parent /*, ...mixins*/) {
+  // Use slice as node 4 does not support param spread.
+  let mixins = Array.prototype.slice.call(arguments, 1);
   class Mixed extends Parent {}
   for (let mixin of mixins) {
     for (let prop in mixin) {


### PR DESCRIPTION
Node 4 doesn't support spreads or splats (...) outside of harmony; support will be added in node 6. Mind avoiding spread for native node support @shuvalov-anton

Ref: https://github.com/nodejs/node/issues/3851